### PR TITLE
Handle process start encoding error

### DIFF
--- a/Editor/ProcessRunner.cs
+++ b/Editor/ProcessRunner.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 			if (string.IsNullOrWhiteSpace(filename))
 				throw new ArgumentException("Filename cannot be null or empty", nameof(filename));
 			
-			return new ProcessStartInfo
+			var processStartInfo = new ProcessStartInfo
 			{
 				UseShellExecute = shell,
 				CreateNoWindow = true,
@@ -64,10 +64,17 @@ namespace Microsoft.Unity.VisualStudio.Editor
 				Arguments = arguments ?? string.Empty,
 				// Performance optimizations
 				WindowStyle = ProcessWindowStyle.Hidden,
-				WorkingDirectory = Environment.CurrentDirectory,
-				StandardOutputEncoding = System.Text.Encoding.UTF8,
-				StandardErrorEncoding = System.Text.Encoding.UTF8
+				WorkingDirectory = Environment.CurrentDirectory
 			};
+			
+			// Only set encoding when redirecting output/error streams
+			if (redirect)
+			{
+				processStartInfo.StandardOutputEncoding = System.Text.Encoding.UTF8;
+				processStartInfo.StandardErrorEncoding = System.Text.Encoding.UTF8;
+			}
+			
+			return processStartInfo;
 		}
 
 		public static void Start(string filename, string arguments)


### PR DESCRIPTION
Conditionally set `StandardOutputEncoding` and `StandardErrorEncoding` in `ProcessRunner.cs` to prevent errors when output is not redirected.

The `StandardOutputEncoding` and `StandardErrorEncoding` properties can only be set when `RedirectStandardOutput` and `RedirectStandardError` are `true`. Previously, these were set unconditionally, causing a `StandardOutputEncoding is only supported when standard output is redirected` error when processes were started without output redirection.

---
<a href="https://cursor.com/background-agent?bcId=bc-371ae3f7-b36f-4e3e-b1bf-a0e887945901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-371ae3f7-b36f-4e3e-b1bf-a0e887945901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

